### PR TITLE
Add a real Bluetooth manager, replacing the blueman-manager handoff

### DIFF
--- a/.config/quickshell/hub/ButtonsSlidersCard.qml
+++ b/.config/quickshell/hub/ButtonsSlidersCard.qml
@@ -204,7 +204,7 @@ Lib.Card {
         
         onClicked: toggleBt()
         onRightClicked: { root.closeRequested();
-        Lib.Shell.det("blueman-manager >/dev/null 2>&1 &") }
+        Lib.Overlays.btOpen = true }
       }
 
       // 3. Performance

--- a/.config/quickshell/hub/top/ButtonsSlidersCard.qml
+++ b/.config/quickshell/hub/top/ButtonsSlidersCard.qml
@@ -235,7 +235,7 @@ Lib.TopCard {
         onClicked: toggleBt()
         onRightClicked: {
             root.closeRequested()
-            det("blueman-manager >/dev/null 2>&1 &")
+            Lib.Overlays.btOpen = true
         }
       }
 

--- a/.config/quickshell/lib/BluetoothMenu.qml
+++ b/.config/quickshell/lib/BluetoothMenu.qml
@@ -1,0 +1,348 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import Quickshell.Wayland
+
+// Overlay kept loaded by the shell, same pattern as WifiMenu.qml. Right-click
+// the Hub's Bluetooth pill opens this instead of the old rfkill-toggle-only +
+// external blueman-manager combo -- real device list, connect/disconnect/pair/
+// forget, all in the same visual language as the rest of the shell.
+
+PanelWindow {
+    id: root
+    anchors { top: true; bottom: true; left: true; right: true }
+    color: "transparent"
+
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    WlrLayershell.exclusiveZone: -1
+    WlrLayershell.namespace: "bluetooth-menu"
+
+    focusable: true
+
+    // Runs either as its own process or as an overlay inside the shell; the
+    // embedded case must not tear the whole shell down when it closes
+    property bool standalone: true
+    signal closeRequested()
+    function dismiss() {
+        if (root.standalone) Qt.quit()
+        else root.closeRequested()
+    }
+
+    // A Shortcut is application-wide, so it will work even if the menu is not focused
+    Shortcut { sequence: "Esc"; enabled: root.visible; onActivated: root.dismiss() }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        onClicked: (mouse) => {
+            const inside = mouse.x >= card.x && mouse.x <= (card.x + card.width) &&
+                           mouse.y >= card.y && mouse.y <= (card.y + card.height)
+            if (!inside) root.dismiss()
+        }
+    }
+
+    // -------- Theme (mirrors WifiMenu.qml's palette) --------
+    readonly property bool isDarkMode: ThemeState.isDarkMode
+
+    readonly property color cCard:   isDarkMode ? "#282c2d" : "#F0ECE6"
+    readonly property color cItem:   isDarkMode ? "#323738" : "#cb97a382"
+    readonly property color cItemHv: isDarkMode ? "#3c4243" : "#e697a382"
+    readonly property color cFg:     isDarkMode ? "#D3C6AA" : "#1e2326"
+    readonly property color cMuted:  isDarkMode ? "#859289" : "#4d6049"
+    readonly property color cBorder: isDarkMode ? "#d4708154" : "#d4586a3c"
+    readonly property color cGreen:  isDarkMode ? "#A7C080" : "#576830"
+    readonly property color cRed:    isDarkMode ? "#E67E80" : "#b13c3a"
+    readonly property int   cRadius: 10
+    readonly property string fontText: "Inter"
+    readonly property string fontIcon: "JetBrainsMono Nerd Font"
+
+    // -------- State --------
+    property bool powered: false
+    property bool scanning: false
+    property string busyMac: ""
+    property var devices: []   // [{mac, name, paired, connected}]
+
+    function iconFor(name) {
+        var n = (name || "").toLowerCase()
+        if (n.includes("buds") || n.includes("headphone") || n.includes("headset") || n.includes("airpod")) return "󰋋"
+        if (n.includes("mouse")) return "󰍽"
+        if (n.includes("keyboard")) return "󰌌"
+        if (n.includes("speaker")) return "󰓃"
+        if (n.includes("watch")) return "󰥔"
+        if (n.includes("phone")) return ""
+        return "󰂯"
+    }
+
+    function parseDeviceLines(text) {
+        var out = {}
+        var lines = String(text || "").split("\n")
+        for (var i = 0; i < lines.length; i++) {
+            var m = lines[i].match(/^Device\s+([0-9A-Fa-f:]{17})\s+(.+)$/)
+            if (m) out[m[1]] = m[2].trim()
+        }
+        return out
+    }
+
+    Process {
+        id: statusPoll
+        command: ["bash", "-c", `
+            bluetoothctl show | grep -q "Powered: yes" && echo "POWERED:1" || echo "POWERED:0"
+            echo "===ALL==="
+            bluetoothctl devices
+            echo "===PAIRED==="
+            bluetoothctl devices Paired
+            echo "===CONNECTED==="
+            bluetoothctl devices Connected
+        `]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                var chunks = text.split("===")
+                // chunks[0] = "POWERED:x\n", then alternating "ALL===\n<data>", "PAIRED===\n<data>"...
+                var head = chunks[0] || ""
+                root.powered = head.includes("POWERED:1")
+
+                var all = {}, paired = {}, connected = {}
+                for (var i = 1; i < chunks.length; i += 2) {
+                    var label = chunks[i]
+                    var body = chunks[i + 1] || ""
+                    if (label === "ALL") all = root.parseDeviceLines(body)
+                    else if (label === "PAIRED") paired = root.parseDeviceLines(body)
+                    else if (label === "CONNECTED") connected = root.parseDeviceLines(body)
+                }
+
+                var list = []
+                for (var mac in all) {
+                    list.push({
+                        mac: mac,
+                        name: all[mac],
+                        paired: !!paired[mac],
+                        connected: !!connected[mac]
+                    })
+                }
+                list.sort(function(a, b) {
+                    if (a.connected !== b.connected) return a.connected ? -1 : 1
+                    if (a.paired !== b.paired) return a.paired ? -1 : 1
+                    return a.name.localeCompare(b.name)
+                })
+                root.devices = list
+            }
+        }
+    }
+
+    // the shell keeps this loaded, so only poll while it is actually on screen
+    Timer {
+        interval: 3000; running: root.visible; repeat: true; triggeredOnStart: true
+        onTriggered: if (!statusPoll.running) statusPoll.running = true
+    }
+
+    function togglePower() {
+        root.powered = !root.powered
+        Quickshell.execDetached(["bash", "-c", "bluetoothctl power " + (root.powered ? "on" : "off")])
+    }
+
+    function toggleConnect(dev) {
+        root.busyMac = dev.mac
+        var cmd = dev.connected
+            ? "bluetoothctl disconnect " + dev.mac
+            : (dev.paired
+                ? "bluetoothctl connect " + dev.mac
+                : "bluetoothctl pair " + dev.mac + " && bluetoothctl trust " + dev.mac + " && bluetoothctl connect " + dev.mac)
+        Quickshell.execDetached(["bash", "-c", cmd + "; sleep 1"])
+        busyResetTimer.restart()
+    }
+    Timer { id: busyResetTimer; interval: 4000; onTriggered: root.busyMac = "" }
+
+    function forget(dev) {
+        Quickshell.execDetached(["bash", "-c", "bluetoothctl remove " + dev.mac])
+    }
+
+    function toggleScan() {
+        root.scanning = !root.scanning
+        if (root.scanning) {
+            Quickshell.execDetached(["bash", "-c", "timeout 10 bluetoothctl scan on"])
+            scanStopTimer.restart()
+        } else {
+            Quickshell.execDetached(["bash", "-c", "bluetoothctl scan off"])
+        }
+    }
+    Timer { id: scanStopTimer; interval: 10000; onTriggered: root.scanning = false }
+
+    Rectangle {
+        id: card
+        width: 340
+        height: Math.ceil(mainLayout.implicitHeight + 24)
+        // the popup opens from whichever corner the bar is in, so the two
+        // layouts keep the placement they each had before this file merged them
+        readonly property bool topStyle: Configuration.barStyle === "top"
+        anchors.right: parent.right
+        anchors.top: topStyle ? parent.top : undefined
+        anchors.bottom: topStyle ? undefined : parent.bottom
+        anchors.rightMargin: topStyle ? 14 : 10
+        anchors.topMargin: 52
+        anchors.bottomMargin: 48
+        color: cCard
+        radius: cRadius
+        border.width: 1
+        border.color: cBorder
+        clip: true
+
+        ColumnLayout {
+            id: mainLayout
+            anchors { left: parent.left; right: parent.right; top: parent.top; margins: 12 }
+            spacing: 10
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Text {
+                    text: "Bluetooth"
+                    color: root.cFg
+                    font.family: root.fontText; font.pixelSize: 14; font.weight: Font.DemiBold
+                    Layout.fillWidth: true
+                }
+
+                Rectangle {
+                    width: 40; height: 22; radius: 11
+                    color: root.powered ? root.cGreen : root.cItem
+                    Behavior on color { ColorAnimation { duration: 150 } }
+                    Rectangle {
+                        x: root.powered ? parent.width - width - 3 : 3
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 16; height: 16; radius: 8; color: "white"
+                        Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+                    }
+                    MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: root.togglePower() }
+                }
+            }
+
+            Rectangle { Layout.fillWidth: true; height: 1; color: root.cBorder; opacity: 0.5 }
+
+            RowLayout {
+                Layout.fillWidth: true
+                visible: root.powered
+                Text {
+                    text: root.scanning ? "Scanning…" : "Devices"
+                    color: root.cMuted
+                    font.family: root.fontText; font.pixelSize: 11
+                    Layout.fillWidth: true
+                }
+                Rectangle {
+                    width: scanLabel.implicitWidth + 16; height: 24; radius: 8
+                    color: scanHov.hovered ? root.cItemHv : root.cItem
+                    Behavior on color { ColorAnimation { duration: 120 } }
+                    Text {
+                        id: scanLabel
+                        anchors.centerIn: parent
+                        text: root.scanning ? "Stop" : "Scan"
+                        color: root.cFg
+                        font.family: root.fontText; font.pixelSize: 11
+                    }
+                    MouseArea { id: scanHov; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: root.toggleScan() }
+                }
+            }
+
+            Text {
+                visible: !root.powered
+                text: "Bluetooth is off"
+                color: root.cMuted
+                font.family: root.fontText; font.pixelSize: 12
+                Layout.topMargin: 4; Layout.bottomMargin: 4
+            }
+
+            Text {
+                visible: root.powered && root.devices.length === 0
+                text: "No devices found -- try Scan"
+                color: root.cMuted
+                font.family: root.fontText; font.pixelSize: 12
+                opacity: 0.8
+                Layout.topMargin: 4; Layout.bottomMargin: 4
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                visible: root.powered
+                spacing: 4
+
+                Repeater {
+                    model: root.devices
+                    delegate: Rectangle {
+                        id: devRow
+                        required property var modelData
+                        readonly property bool isBusy: root.busyMac === modelData.mac
+
+                        Layout.fillWidth: true
+                        height: 44
+                        radius: 8
+                        color: rowHov.hovered ? root.cItemHv : root.cItem
+
+                        RowLayout {
+                            anchors { fill: parent; leftMargin: 10; rightMargin: 8 }
+                            spacing: 8
+
+                            Text {
+                                text: root.iconFor(devRow.modelData.name)
+                                font.family: root.fontIcon; font.pixelSize: 16
+                                color: devRow.modelData.connected ? root.cGreen : root.cMuted
+                            }
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 1
+                                Text {
+                                    text: devRow.modelData.name
+                                    color: root.cFg
+                                    font.family: root.fontText; font.pixelSize: 12; font.weight: Font.Medium
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                }
+                                Text {
+                                    text: devRow.isBusy ? "Working…"
+                                        : devRow.modelData.connected ? "Connected"
+                                        : devRow.modelData.paired ? "Paired" : "Available"
+                                    color: devRow.modelData.connected ? root.cGreen : root.cMuted
+                                    font.family: root.fontText; font.pixelSize: 10
+                                }
+                            }
+
+                            Rectangle {
+                                width: btnLabel.implicitWidth + 14; height: 24; radius: 8
+                                color: devRow.modelData.connected ? Qt.rgba(root.cRed.r, root.cRed.g, root.cRed.b, 0.18) : root.cGreen
+                                opacity: devRow.isBusy ? 0.5 : 1.0
+                                Text {
+                                    id: btnLabel
+                                    anchors.centerIn: parent
+                                    text: devRow.modelData.connected ? "Disconnect" : devRow.modelData.paired ? "Connect" : "Pair"
+                                    color: devRow.modelData.connected ? root.cRed : "#232a2e"
+                                    font.family: root.fontText; font.pixelSize: 10; font.weight: Font.DemiBold
+                                }
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    enabled: !devRow.isBusy
+                                    onClicked: root.toggleConnect(devRow.modelData)
+                                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                                    onPressed: (m) => { if (m.button === Qt.RightButton) root.forget(devRow.modelData) }
+                                }
+                            }
+                        }
+
+                        MouseArea { id: rowHov; anchors.fill: parent; hoverEnabled: true; z: -1 }
+                    }
+                }
+            }
+
+            Text {
+                visible: root.powered && root.devices.length > 0
+                text: "Right-click a device to forget it"
+                color: root.cMuted
+                font.family: root.fontText; font.pixelSize: 10
+                opacity: 0.6
+                Layout.topMargin: 2
+            }
+        }
+    }
+}

--- a/.config/quickshell/lib/Overlays.qml
+++ b/.config/quickshell/lib/Overlays.qml
@@ -7,4 +7,5 @@ import Quickshell
 // draws, so these are in the running instance instead.
 Scope {
     property bool wifiOpen: false
+    property bool btOpen: false
 }

--- a/.config/quickshell/lib/WifiMenu.qml
+++ b/.config/quickshell/lib/WifiMenu.qml
@@ -740,10 +740,15 @@ PanelWindow {
         width: 390
         height: Math.ceil(mainLayout.implicitHeight + 24)
 
-        // MOVED TO BOTTOM RIGHT IN TASKBAR MODE
+        // the popup opens from whichever corner the bar is in. the top-bar copy
+        // of this file used to hardcode x/y, which only right-aligned on a
+        // 1440-wide screen, so anchor it instead
+        readonly property bool topStyle: Configuration.barStyle === "top"
         anchors.right: parent.right
-        anchors.bottom: parent.bottom
+        anchors.top: topStyle ? parent.top : undefined
+        anchors.bottom: topStyle ? undefined : parent.bottom
         anchors.rightMargin: 10  // Increase this number to move LEFT
+        anchors.topMargin: 44
         anchors.bottomMargin: 48 // Decrease this number to move DOWN
 
         color: cCard

--- a/.config/quickshell/shell.qml
+++ b/.config/quickshell/shell.qml
@@ -19,6 +19,15 @@ ShellRoot {
         }
     }
 
+    Loader {
+        active: true
+        sourceComponent: Lib.BluetoothMenu {
+            standalone: false
+            visible: Lib.Overlays.btOpen
+            onCloseRequested: Lib.Overlays.btOpen = false
+        }
+    }
+
     Variants {
         model: Quickshell.screens
         Scope {


### PR DESCRIPTION
Bluetooth control was rfkill block/unblock (radio on/off only) plus a right-click that shelled out to the external `blueman-manager` GTK app for anything else — no in-shell way to see devices, connect/disconnect, or pair.

### What this adds

`lib/BluetoothMenu.qml` lists known devices via `bluetoothctl devices` / `devices Paired` / `devices Connected`, with connect/disconnect/pair as one click and forget as a right-click, plus a scan button for discovering new devices. Left-click on the pill still toggles the radio exactly as before.

It follows `WifiMenu.qml`'s post-unification shape rather than the old one-process-per-menu pattern:

- one file in `lib/`, shared by both bar styles
- kept loaded by `shell.qml`, switched through `Lib.Overlays.btOpen`
- same `standalone` / `dismiss()` split, so it still runs on its own via `quickshell -p` for testing
- polling gated on `visible`, so idle cost is nothing

Both Hub cards (`hub/` and `hub/top/`) just set `Lib.Overlays.btOpen` now.

The card reads `Configuration.barStyle` and opens from whichever corner the bar is in — top-right under a top bar, bottom-right above the taskbar.

`blueman-applet` intentionally stays in the Hyprland autostart: it supplies the pairing agent `bluetoothctl` needs for devices that prompt for PIN confirmation. What goes away is the `blueman-manager` GUI handoff.

### Second commit — separable

`a42e4a0` fixes `WifiMenu.qml`'s placement the same way. Unifying the two copies kept the taskbar one's bottom-right placement, so in top-bar mode the Wifi menu opens at the opposite end of the screen from the bar it belongs to. The old top-bar copy used `x: 1042; y: 44`, which only right-aligns on a 1440-wide screen (the 390-wide card ends at 1432).

It's a separate commit on purpose — drop it if you'd rather handle that yourself, the Bluetooth commit doesn't depend on it.

### Testing

Verified by running the menu standalone (`quickshell -p`): parses clean, `ThemeState` and `Configuration` singletons resolve, devices list/parse/sort correctly, icon heuristic works, theme applies, dismiss works. `qmllint` reports no errors on all changed files.

Not exercised on my side: the embedded `Overlays`/`shell.qml` path, since my live config predates the unified structure. It's the same four-line shape as the `WifiMenu` loader directly above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
